### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/115/882/147/3/1158821473.geojson
+++ b/data/115/882/147/3/1158821473.geojson
@@ -30,11 +30,17 @@
     "name:amh_x_preferred":[
         "\u1276\u12a8\u120b\u12cd"
     ],
+    "name:anp_x_preferred":[
+        "\u091f\u094b\u0915\u0947\u0932\u093e\u0909"
+    ],
     "name:ara_x_preferred":[
         "\u062a\u0648\u0643\u064a\u0644\u0627\u0648"
     ],
     "name:arg_x_preferred":[
         "Tokelau"
+    ],
+    "name:arz_x_preferred":[
+        "\u062a\u0648\u0643\u064a\u0644\u0627\u0648"
     ],
     "name:ast_x_preferred":[
         "Tokel\u00e1u"
@@ -57,6 +63,9 @@
     "name:ben_x_preferred":[
         "\u099f\u0995\u09c7\u09b2\u09cd\u09af\u09c1"
     ],
+    "name:ben_x_variant":[
+        "\u099f\u09cb\u0995\u09c7\u09b2\u09be\u0989"
+    ],
     "name:bos_x_preferred":[
         "Tokelau"
     ],
@@ -78,8 +87,17 @@
     "name:cdo_x_preferred":[
         "Tokelau"
     ],
+    "name:ceb_x_preferred":[
+        "Tokelaw"
+    ],
     "name:ces_x_preferred":[
         "Tokelau"
+    ],
+    "name:chr_x_preferred":[
+        "\u13d9\u13a8\u13b3\u13a4"
+    ],
+    "name:ckb_x_preferred":[
+        "\u062a\u0648\u06a9\u06cc\u0644\u0627\u0648"
     ],
     "name:cor_x_preferred":[
         "Tokelau"
@@ -151,6 +169,9 @@
         "Tokelau"
     ],
     "name:hak_x_preferred":[
+        "Tokelau"
+    ],
+    "name:haw_x_preferred":[
         "Tokelau"
     ],
     "name:heb_x_preferred":[
@@ -225,17 +246,29 @@
     "name:lit_x_preferred":[
         "Tokelau"
     ],
+    "name:lld_x_preferred":[
+        "Tokelau"
+    ],
     "name:mal_x_preferred":[
         "\u0d1f\u0d4b\u0d15\u0d4d\u200c\u0d32\u0d35\u0d4d \u0d26\u0d4d\u0d35\u0d40\u0d2a\u0d41\u0d15\u0d7e"
     ],
     "name:mar_x_preferred":[
         "\u091f\u094b\u0915\u0947\u0932\u093e\u0909"
     ],
+    "name:mdf_x_preferred":[
+        "\u0422\u043e\u043a\u044d\u043b\u0430\u0443"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u043e\u043a\u0435\u043b\u0430\u0443"
     ],
     "name:mlt_x_preferred":[
         "Tokelaw"
+    ],
+    "name:mlt_x_variant":[
+        "Tokelau"
+    ],
+    "name:mri_x_preferred":[
+        "Tokerau"
     ],
     "name:msa_x_preferred":[
         "Tokelau"
@@ -282,6 +315,9 @@
     "name:por_x_preferred":[
         "Tokelau"
     ],
+    "name:pus_x_preferred":[
+        "\u062a\u0648\u06a9\u0644\u0627\u0648"
+    ],
     "name:ron_x_preferred":[
         "Tokelau"
     ],
@@ -297,11 +333,17 @@
     "name:sco_x_preferred":[
         "Tokelau"
     ],
+    "name:shn_x_preferred":[
+        "\u1011\u1030\u101d\u103a\u1038\u1075\u1031\u1087\u101c\u1062\u101d\u103a\u1087"
+    ],
     "name:slk_x_preferred":[
         "Tokelau"
     ],
     "name:slv_x_preferred":[
         "Tokelau"
+    ],
+    "name:slv_x_variant":[
+        "Tokelav"
     ],
     "name:smo_x_preferred":[
         "To'elau"
@@ -339,6 +381,12 @@
     "name:tha_x_preferred":[
         "\u0e42\u0e17\u0e40\u0e04\u0e2d\u0e40\u0e25\u0e32"
     ],
+    "name:tha_x_variant":[
+        "\u0e42\u0e15\u0e40\u0e01\u0e40\u0e25\u0e32"
+    ],
+    "name:ton_x_preferred":[
+        "Tokelau"
+    ],
     "name:tur_x_preferred":[
         "Tokelau"
     ],
@@ -368,6 +416,9 @@
     ],
     "name:wuu_x_preferred":[
         "\u6258\u514b\u52b3"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e2\u10dd\u10d9\u10d4\u10da\u10d0\u10e3"
     ],
     "name:yor_x_preferred":[
         "Tokelau"
@@ -549,7 +600,7 @@
         }
     ],
     "wof:id":1158821473,
-    "wof:lastmodified":1617827450,
+    "wof:lastmodified":1690870959,
     "wof:name":"Tokelau Islands",
     "wof:parent_id":136253053,
     "wof:placetype":"dependency",

--- a/data/890/434/767/890434767.geojson
+++ b/data/890/434/767/890434767.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:afr_x_preferred":[
+        "Atafu"
+    ],
     "name:ara_x_preferred":[
         "\u0623\u062a\u0627\u0641\u0648"
     ],
@@ -52,6 +55,9 @@
     "name:est_x_preferred":[
         "Atafu"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u062a\u0627\u0641\u0648"
+    ],
     "name:fin_x_preferred":[
         "Atafu"
     ],
@@ -73,6 +79,9 @@
     "name:ind_x_preferred":[
         "Atafu"
     ],
+    "name:isl_x_preferred":[
+        "Atafu"
+    ],
     "name:ita_x_preferred":[
         "Atafu"
     ],
@@ -85,7 +94,13 @@
     "name:lat_x_preferred":[
         "Atafu"
     ],
+    "name:lav_x_preferred":[
+        "Atafu"
+    ],
     "name:lit_x_preferred":[
+        "Atafu"
+    ],
+    "name:msa_x_preferred":[
         "Atafu"
     ],
     "name:nld_x_preferred":[
@@ -97,8 +112,14 @@
     "name:nor_x_preferred":[
         "Atafu"
     ],
+    "name:pih_x_preferred":[
+        "Atafu"
+    ],
     "name:pol_x_preferred":[
         "Atafu"
+    ],
+    "name:pus_x_preferred":[
+        "\u0622\u062a\u0627\u0641\u0648"
     ],
     "name:ron_x_preferred":[
         "Atafu"
@@ -136,6 +157,9 @@
     "name:urd_x_preferred":[
         "\u0627\u0679\u0627\u0641\u0648"
     ],
+    "name:yue_x_preferred":[
+        "\u963f\u5854\u5bcc"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u5854\u5bcc\u74b0\u7901"
     ],
@@ -163,7 +187,7 @@
         }
     ],
     "wof:id":890434767,
-    "wof:lastmodified":1566666592,
+    "wof:lastmodified":1690870959,
     "wof:name":"Atafu Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/445/671/890445671.geojson
+++ b/data/890/445/671/890445671.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":7.0,
+    "name:afr_x_preferred":[
+        "Atafu"
+    ],
     "name:ara_x_preferred":[
         "\u0623\u062a\u0627\u0641\u0648"
     ],
@@ -55,6 +58,9 @@
     "name:est_x_preferred":[
         "Atafu"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u062a\u0627\u0641\u0648"
+    ],
     "name:fin_x_preferred":[
         "Atafu"
     ],
@@ -73,6 +79,9 @@
     "name:ind_x_preferred":[
         "Atafu"
     ],
+    "name:isl_x_preferred":[
+        "Atafu"
+    ],
     "name:ita_x_preferred":[
         "Atafu"
     ],
@@ -85,7 +94,13 @@
     "name:lat_x_preferred":[
         "Atafu"
     ],
+    "name:lav_x_preferred":[
+        "Atafu"
+    ],
     "name:lit_x_preferred":[
+        "Atafu"
+    ],
+    "name:msa_x_preferred":[
         "Atafu"
     ],
     "name:nld_x_preferred":[
@@ -94,8 +109,14 @@
     "name:nob_x_preferred":[
         "Atafu"
     ],
+    "name:pih_x_preferred":[
+        "Atafu"
+    ],
     "name:pol_x_preferred":[
         "Atafu"
+    ],
+    "name:pus_x_preferred":[
+        "\u0622\u062a\u0627\u0641\u0648"
     ],
     "name:ron_x_preferred":[
         "Atafu"
@@ -129,6 +150,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0627\u0679\u0627\u0641\u0648"
+    ],
+    "name:yue_x_preferred":[
+        "\u963f\u5854\u5bcc"
     ],
     "name:zho_x_preferred":[
         "\u963f\u5854\u5bcc\u74b0\u7901"
@@ -256,7 +280,7 @@
         }
     ],
     "wof:id":890445671,
-    "wof:lastmodified":1566666592,
+    "wof:lastmodified":1690870958,
     "wof:name":"Atafu Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.